### PR TITLE
Update CPAL 2026 organizers

### DIFF
--- a/_db/data/cpal_2026.py
+++ b/_db/data/cpal_2026.py
@@ -626,7 +626,7 @@ def make_organizers():
     organizers.append(
         Organizer(
             name="Haotong Qin",
-            role="Local Chair",
+            role="Tutorial Chair",
             website="https://htqin.github.io/",
             affiliation="ETH",
             photo="qin.png",
@@ -689,7 +689,7 @@ def make_organizers():
             name="Souvik Kundu",
             role="Industry Liaison Chair",
             website="https://ksouvik52.github.io/",
-            affiliation="Google",
+            affiliation="Intel",
             photo="kundu.jpeg",
         )
     )
@@ -723,17 +723,6 @@ def make_organizers():
             website="https://tianlong-chen.github.io/",
             affiliation="UNC Chapel Hill",
             photo="chen_t.jpeg",
-        )
-    )
-
-    # Tutorial Chair
-    organizers.append(
-        Organizer(
-            name="Chong You",
-            role="Tutorial Chair",
-            website="https://sites.google.com/view/cyou",
-            affiliation="Google",
-            photo="cy.jpeg",
         )
     )
 

--- a/_organizers/kundu_souvik_il_544078.md
+++ b/_organizers/kundu_souvik_il_544078.md
@@ -1,7 +1,7 @@
 ---
 name: "Souvik Kundu"
 role: "Industry Liaison Chair"
-affiliation: "Google"
+affiliation: "Intel"
 website: "https://ksouvik52.github.io/"
 photo: "kundu.jpeg"
 ---

--- a/_organizers/qin_haotong_tc_544078.md
+++ b/_organizers/qin_haotong_tc_544078.md
@@ -1,6 +1,6 @@
 ---
 name: "Haotong Qin"
-role: "Local Chair"
+role: "Tutorial Chair"
 affiliation: "ETH"
 website: "https://htqin.github.io/"
 photo: "qin.png"

--- a/_organizers/you_chong_tc_544078.md
+++ b/_organizers/you_chong_tc_544078.md
@@ -1,7 +1,0 @@
----
-name: "Chong You"
-role: "Tutorial Chair"
-affiliation: "Google"
-website: "https://sites.google.com/view/cyou"
-photo: "cy.jpeg"
----


### PR DESCRIPTION
Updates to CPAL 2026 organizer information:

- Fix Souvik Kundu affiliation from Google to Intel
- Remove Chong You from 2026 organizers
- Move Haotong Qin from Local Chair to Tutorial Chair

Resolves #2

🤖 Generated with [Claude Code](https://claude.ai/code)